### PR TITLE
Feature/widgets manager improve relative to position configuration

### DIFF
--- a/packages/widgets-manager/CHANGELOG.md
+++ b/packages/widgets-manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased - 2019-05-28
+### Release (shuld be 1.0.0 because there are breaking changes)
+- 'relative-to-position' position strategy changes format
+- **BREAKING CHANGES**: Format for relative to postion changes from:
+  - { offset: Position } to { offsetX: offsetX, offsetY: offsetY }
+
 ## Release [0.7.0] - 2018-12-12
 ### Release
 - Suport new type lt-webrtc

--- a/packages/widgets-manager/package.json
+++ b/packages/widgets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-talk/widgets-manager",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Minimal widgets manager implementation to allow load / remove apps on a page",
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/widgets-manager/src/grid.spec.ts
+++ b/packages/widgets-manager/src/grid.spec.ts
@@ -7,7 +7,14 @@ const mockPositionRelativeToPosition: AppPosition = {
   type: 'relative-to-position',
   payload: {
     positionId: 'mid-center',
-    offset: { top: 0, right: 0, bottom: 0, left: 0 },
+    offsetX: {
+      relationType: 'LL',
+      value: 0,
+    },
+    offsetY: {
+      relationType: 'BT',
+      value: 0,
+    }
   }
 };
 
@@ -48,6 +55,10 @@ describe('GridManager', () => {
 
   it('creates and configures a GridManager', () => {
     const gm = new GridManager(settings, windowObject, addStrategy);
+
+    const cellHeight = windowObject.innerHeight / 3;
+    const cellWidth = windowObject.innerWidth / 3;
+
     expect(gm.grid.cells.length).toBe(9);
     expect(gm.grid.cells).toContainEqual(
       {
@@ -55,8 +66,8 @@ describe('GridManager', () => {
         apps: [],
         position: {
           top: 0,
-          right: 0,
-          bottom: 0,
+          right: cellWidth,
+          bottom: cellHeight,
           left: 0,
         },
         size: {
@@ -72,8 +83,8 @@ describe('GridManager', () => {
         apps: [],
         position: {
           top: 0,
-          right: 0,
-          bottom: 0,
+          right: 3 * cellWidth,
+          bottom: cellHeight,
           left: 2 * (windowObject.innerWidth / 3),
         },
         size: {
@@ -92,6 +103,9 @@ describe('GridManager', () => {
 
     gm._setGridDimensions(1, mobileWidth, mobileHeight);
 
+    const cellHeight = mobileHeight / 9;
+    const cellWidth = mobileWidth;
+
     expect(gm.grid.cells.length).toBe(9);
     expect(gm.grid.cells).toContainEqual(
       {
@@ -99,8 +113,8 @@ describe('GridManager', () => {
         apps: [],
         position: {
           top: 0,
-          right: 0,
-          bottom: 0,
+          right: cellWidth,
+          bottom: cellHeight,
           left: 0,
         },
         size: {
@@ -115,9 +129,9 @@ describe('GridManager', () => {
         id: 'top-center',
         apps: [],
         position: {
-          top: mobileHeight / 9,
-          right: 0,
-          bottom: 0,
+          top: cellHeight,
+          right: cellWidth,
+          bottom: 2 * cellHeight,
           left: 0,
         },
         size: {
@@ -148,20 +162,23 @@ describe('GridManager', () => {
     }
 
     gm.addAppToCell('mid-center', mockApp1);
-    const cell = gm.getGridCell('mid-center')
+    const cell = gm.getGridCell('mid-center');
+
+    const cellHeight = windowObject.innerHeight / 3;
+    const cellWidth = windowObject.innerWidth / 3;
     
     expect(cell).toMatchObject({
       id: 'mid-center',
       apps: [mockApp1],
       position: {
-        left: windowObject.innerWidth / 3,
-        right: 0,
-        bottom: 0,
-        top: windowObject.innerHeight / 3,
+        left: cellWidth,
+        right: 2 * cellWidth,
+        bottom: 2 * cellHeight,
+        top: cellHeight,
       },
       size: {
-        width: windowObject.innerWidth / 3,
-        height: windowObject.innerHeight / 3,
+        width: cellWidth,
+        height: cellHeight,
       }
     });
   });
@@ -317,19 +334,22 @@ describe('GridManager', () => {
     gm.addAppToCell('mid-center', mockApp1);
     gm.removeApp(1);
     const cell = gm.getGridCell('mid-center');
+
+    const cellHeight = windowObject.innerHeight / 3;
+    const cellWidth = windowObject.innerWidth / 3;
     
     expect(cell).toMatchObject({
       id: 'mid-center',
       apps: [],
       position: {
-        top: 1 * (windowObject.innerHeight / 3),
-        right: 0,
-        bottom: 0,
-        left: 1 * (windowObject.innerWidth / 3),
+        top: 1 * (cellHeight),
+        right: 2 * cellWidth,
+        bottom: 2 * cellHeight,
+        left: 1 * cellWidth,
       },
       size: {
-        width: windowObject.innerWidth / 3,
-        height: windowObject.innerHeight / 3,
+        width: cellWidth,
+        height: cellHeight,
       }
     });
   });

--- a/packages/widgets-manager/src/grid.ts
+++ b/packages/widgets-manager/src/grid.ts
@@ -50,7 +50,9 @@ export class GridManager {
       cell.size.height = height / numberOfRows;
       
       cell.position.left = column * cell.size.width;
+      cell.position.right = (column * cell.size.width) + cell.size.width;
       cell.position.top = row * cell.size.height;
+      cell.position.bottom = (row * cell.size.height) + cell.size.height;
     });
   }
 

--- a/packages/widgets-manager/src/manager.spec.ts
+++ b/packages/widgets-manager/src/manager.spec.ts
@@ -21,7 +21,14 @@ const mockPositionRelativeToPosition: AppPosition = {
   type: 'relative-to-position',
   payload: {
     positionId: 'mid-center',
-    offset: { top: 0, right: 0, bottom: 0, left: 0 },
+    offsetX: {
+      relationType: 'LL',
+      value: 0,
+    },
+    offsetY: {
+      relationType: 'BT',
+      value: 0,
+    }
   }
 };
 
@@ -29,7 +36,14 @@ const mockPositionRelativeToPosition2: AppPosition = {
   type: 'relative-to-position',
   payload: {
     positionId: 'bottom-left',
-    offset: { top: 0, right: 0, bottom: 0, left: 0 },
+    offsetX: {
+      relationType: 'LL',
+      value: 0,
+    },
+    offsetY: {
+      relationType: 'BT',
+      value: 0,
+    }
   }
 };
 

--- a/packages/widgets-manager/src/strategies/position/relativeToElement.ts
+++ b/packages/widgets-manager/src/strategies/position/relativeToElement.ts
@@ -16,7 +16,8 @@ export class RelativeToElementPositionStrategy implements PositionStrategy {
     const relativeToId = position.payload.relativeId;
     const htmlFloatType = makeHTMLFloatType(position.payload.floatType);
     const elementPositon = getElementPosition(relativeToId, htmlFloatType);
-    const relativePosition = getRelativePosition(elementPositon, position);
+    const relativeInfo = { offsetX: position.payload.offsetX, offsetY: position.payload.offsetY };
+    const relativePosition = getRelativePosition(elementPositon, relativeInfo);
 
     return relativePosition;
   };

--- a/packages/widgets-manager/src/strategies/position/relativeToPosition.spec.ts
+++ b/packages/widgets-manager/src/strategies/position/relativeToPosition.spec.ts
@@ -5,7 +5,14 @@ const mockPositionRelativeToPosition: AppPosition = {
   type: 'relative-to-position',
   payload: {
     positionId: 'mid-center',
-    offset: { top: 0, right: 0, bottom: 0, left: 0 },
+    offsetX: {
+      relationType: 'LL',
+      value: 0,
+    },
+    offsetY: {
+      relationType: 'TB',
+      value: 0,
+    }
   }
 };
 

--- a/packages/widgets-manager/src/strategies/position/relativeToPosition.ts
+++ b/packages/widgets-manager/src/strategies/position/relativeToPosition.ts
@@ -2,6 +2,7 @@ import { POSITION_RELATIVE_TO_PLACE } from './../../constants';
 import { GridCell } from './../../types';
 import { App, ObjectIndex, PositionStrategy } from "../../types";
 import { ReplaceAppStrategy } from '../mounting/replace';
+import { getRelativePosition } from '../../utils';
 
 export class RelativeToPlacePositionStrategy implements PositionStrategy {
   public getPositionProps(app: App, cell: GridCell): ObjectIndex {
@@ -9,12 +10,11 @@ export class RelativeToPlacePositionStrategy implements PositionStrategy {
     if (position.type !== POSITION_RELATIVE_TO_PLACE) {
       throw Error('Can not get position props from an element that does not implement relativeToPlace strategy');
     }
-    const left = cell.position.left + position.payload.offset.left;
-    const top = cell.position.top + position.payload.offset.top;
-    return {
-      top: `${top}px`,
-      left: `${left}px`
-    }
+    
+    const relativeInfo = { offsetX: position.payload.offsetX, offsetY: position.payload.offsetY };
+    const relativePosition = getRelativePosition(cell.position, relativeInfo);
+
+    return relativePosition;
   };
   
   public shouldAddNewPosition = () => false;

--- a/packages/widgets-manager/src/types.ts
+++ b/packages/widgets-manager/src/types.ts
@@ -41,6 +41,11 @@ export type offsetY = {
   value: number;
 }
 
+export type RelativeCoords = {
+  offsetX: offsetX,
+  offsetY: offsetY,
+}
+
 export type RelativeToElementPosition = {
   type: 'relative-to-element';
   payload: {
@@ -55,7 +60,8 @@ export type RelativeToPlacePosition = {
   type: 'relative-to-position';
   payload: {
     positionId: string;
-    offset: Position,
+    offsetX: offsetX,
+    offsetY: offsetY,
   }
 }
 

--- a/packages/widgets-manager/src/utils/index.spec.ts
+++ b/packages/widgets-manager/src/utils/index.spec.ts
@@ -1,6 +1,6 @@
-import { relationTypeX, relationTypeY } from './../types';
+import { relationTypeX, relationTypeY, RelativeCoords } from './../types';
 import { diffBy, getElementPosition, getRelativePosition } from './';
-import { HTMLFloatType, Position, RelativeToElementPosition } from '../types';
+import { HTMLFloatType, Position } from '../types';
 
 describe('utils/index', () => {
   describe('diffBy', () => {
@@ -117,19 +117,14 @@ describe('utils/index', () => {
     };
 
     const generateMockPositionConfig = (relationTypeX: relationTypeX, relationTypeY: relationTypeY) => {
-      const mockPositionConfig: RelativeToElementPosition = {
-        type: 'relative-to-element',
-        payload: {
-          relativeId: 'lt-messenger-iframe',
-          floatType: HTMLFloatType.fixed,
-          offsetX: {
-            relationType: relationTypeX,
-            value: 0,
-          },
-          offsetY: {
-            relationType: relationTypeY,
-            value: 0,
-          }
+      const mockPositionConfig: RelativeCoords = {
+        offsetX: {
+          relationType: relationTypeX,
+          value: 0,
+        },
+        offsetY: {
+          relationType: relationTypeY,
+          value: 0,
         }
       };
     

--- a/packages/widgets-manager/src/utils/index.ts
+++ b/packages/widgets-manager/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { RELATIVE_X_LEFT_LEFT, RELATIVE_X_LEFT_RIGHT, RELATIVE_X_RIGHT_LEFT, RELATIVE_X_RIGHT_RIGHT, RELATIVE_Y_TOP_TOP, RELATIVE_Y_TOP_BOTTOM, RELATIVE_Y_BOTTOM_BOTTOM, RELATIVE_Y_BOTTOM_TOP } from './../constants';
-import { Position, HTMLFloatType, ObjectIndex, RelativeToElementPosition } from './../types';
+import { Position, HTMLFloatType, ObjectIndex, RelativeCoords } from './../types';
 
 /**
  * Return an element by its id or throws an error if it can not find one
@@ -60,40 +60,40 @@ export const getElementPosition = (elementId: string, elementFloatType: HTMLFloa
   }
 }
 
-export const getRelativePosition = (elementPositon: Position, positionConfig: RelativeToElementPosition): ObjectIndex => {
+export const getRelativePosition = (elementPositon: Position, relativeInfo: RelativeCoords): ObjectIndex => {
     const { top, right, bottom, left } = elementPositon;
-    const { innerHeight, innerWidth } = window
+    const { innerHeight, innerWidth } = window;
     let offset: ObjectIndex = {};
-    switch (positionConfig.payload.offsetX.relationType) {
+    switch (relativeInfo.offsetX.relationType) {
       case RELATIVE_X_LEFT_LEFT:
-        offset.left = `${left + positionConfig.payload.offsetX.value}px`
+        offset.left = `${left + relativeInfo.offsetX.value}px`
         break;
       case RELATIVE_X_LEFT_RIGHT:
-        offset.left = `${right + positionConfig.payload.offsetX.value}px`
+        offset.left = `${right + relativeInfo.offsetX.value}px`
         break;
       case RELATIVE_X_RIGHT_LEFT:
-        offset.right = `${innerWidth - left + positionConfig.payload.offsetX.value}px`
+        offset.right = `${innerWidth - left + relativeInfo.offsetX.value}px`
         break;
       case RELATIVE_X_RIGHT_RIGHT:
-        offset.right = `${innerWidth - right + positionConfig.payload.offsetX.value}px`
+        offset.right = `${innerWidth - right + relativeInfo.offsetX.value}px`
         break;
     
       default:
         break;
     }
 
-    switch (positionConfig.payload.offsetY.relationType) {
+    switch (relativeInfo.offsetY.relationType) {
       case RELATIVE_Y_TOP_TOP:
-        offset.top = `${top + positionConfig.payload.offsetY.value}px`
+        offset.top = `${top + relativeInfo.offsetY.value}px`
         break;
       case RELATIVE_Y_TOP_BOTTOM:
-        offset.top = `${bottom + positionConfig.payload.offsetY.value}px`
+        offset.top = `${bottom + relativeInfo.offsetY.value}px`
         break;
       case RELATIVE_Y_BOTTOM_TOP:
-        offset.bottom = `${innerHeight - top + positionConfig.payload.offsetY.value}px`
+        offset.bottom = `${innerHeight - top + relativeInfo.offsetY.value}px`
         break;
       case RELATIVE_Y_BOTTOM_BOTTOM:
-        offset.bottom = `${innerHeight - bottom + positionConfig.payload.offsetY.value}px`
+        offset.bottom = `${innerHeight - bottom + relativeInfo.offsetY.value}px`
         break;
     
       default:


### PR DESCRIPTION
**Description**

In order to allow apps to be positioned relative to Grid cells, we need a better syntax to define this relation. We use the same syntax we used to define the position relative to any Dom element:

Important to note that when setting an element top, bottom, left and right positions we follow the DOM getBoundingClientRect that follow this convention:

<img width="855" alt="Screen Shot 2019-05-29 at 11 18 14 AM" src="https://user-images.githubusercontent.com/466105/58569282-cf8abe80-8203-11e9-87cb-5ac73e1d2b34.png">


```typescript
export type offsetX = {
  relationType: relationTypeX;
  value: number;
}

export type offsetY = {
  relationType: relationTypeY;
  value: number;
}

export type RelativeCoords = {
  offsetX: offsetX,
  offsetY: offsetY,
}

export type RelativeToPlacePosition = {
  type: 'relative-to-position';
  payload: {
    positionId: string;
    offsetX: offsetX,
    offsetY: offsetY,
  }
}
```

So following this we can say an app is configured as follows:

```javascript
{
  type: 'relative-to-position';
  payload: {
    positionId: 'bottom-rigth',
    offsetX: {
      relationType: 'RR',
      value: 10,
    },
    offsetY: {
      relationType: 'BB',
      value: 0,
    },
  }
}
```

Above configuration is like saying 

> My right should be aligned to the right of the bottom-right cell of the grid plus 10

 and 

> My bottom should be aligned to the bottom of the bottom-right cell of the grid.

**Acceptance Tests**

- Cells have all properties (bottom, top, left, right) required to calculate its position
- I can configure a Relative to position app and it is positioned where I want to 

**Commercial Value**
- More flexibility for us to place apps in the screen
