### PR TITLE
Add support to executeAppMethods

### DIFF
--- a/packages/apps-sdk/package.json
+++ b/packages/apps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-talk/apps-sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "SDK for apps running on letstalk plataform",
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/apps-sdk/src/constants.ts
+++ b/packages/apps-sdk/src/constants.ts
@@ -1,8 +1,11 @@
-// Apps SDK Events
+// Apps SDK Events (send events)
 export const EVENT_TYPE_LOAD_APP = 'launcher-load-app';
 export const EVENT_TYPE_REMOVE_APP = 'launcher-remove-app';
 export const EVENT_TYPE_GET_APP_SETTINGS = 'launcher-get-app-settings';
 export const EVENT_TYPE_NOTIFY_APP_EVENT = 'launcher-notify-app-event';
+
+// Apps SDK Events (listen events)
+export const EVENT_TYPE_EXECUTE_APP_METHOD = 'launcher-execute-app-method';
 
 // Apps Modes
 export const APP_MODE_IFRAME = 'iframe';


### PR DESCRIPTION
**Description**

Add a new method to the AppsSDK library addEventHandlers() that allows an app to expose all method it can respond to.
 

**Acceptance criteria**

The most important changes here where:

- [x] Should expose the method `addEventHandlers`
- [x] When an event of type `launcher-execute-app-method` arrives then we execute the registered handlers.

**Commercial value**

Allow apps to expose a method that can be called by other apps to execute functionality
