### PR TITLE
Widget manager (1/3) add redux to handle state change in a predictable way

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,13 @@
 docker-defaults: &docker-defaults
   docker:
     # specify the version you desire here
-    - image: circleci/node:latest-browsers
+    - image: circleci/node:12
   working_directory: ~/chat-utils
 
 build-and-test-defaults: &build-and-test-defaults
   docker:
     # specify the version you desire here
-    - image: circleci/node:latest-browsers
+    - image: circleci/node:12
   working_directory: ~/chat-utils
   steps:
       - run:

--- a/packages/widgets-manager/package.json
+++ b/packages/widgets-manager/package.json
@@ -20,12 +20,16 @@
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
+    "redux-observable": "^1.2.0",
+    "rxjs": "^6.5.3"
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
     "@types/qs": "^6.5.3",
     "@types/redux-logger": "^3.0.7",
+    "@types/redux-mock-store": "^1.0.1",
     "jest": "^23.5.0",
+    "redux-mock-store": "^1.5.3",
     "ts-jest": "^24.0.0"
   }
 }

--- a/packages/widgets-manager/package.json
+++ b/packages/widgets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-talk/widgets-manager",
-  "version": "1.1.0",
+  "version": "2.0.0-beta-2",
   "description": "Minimal widgets manager implementation to allow load / remove apps on a page",
   "scripts": {
     "prepublishOnly": "tsc",
@@ -16,20 +16,20 @@
     "access": "public"
   },
   "dependencies": {
-    "qs": "^6.7.0"
+    "debug": "^4.1.1",
+    "firebase": "^7.2.0",
+    "qs": "^6.7.0",
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
-    "redux-observable": "^1.2.0",
-    "rxjs": "^6.5.3"
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
+    "@types/lodash": "^4.14.144",
     "@types/qs": "^6.5.3",
     "@types/redux-logger": "^3.0.7",
-    "@types/redux-mock-store": "^1.0.1",
     "jest": "^23.5.0",
-    "redux-mock-store": "^1.5.3",
     "ts-jest": "^24.0.0"
   }
 }

--- a/packages/widgets-manager/package.json
+++ b/packages/widgets-manager/package.json
@@ -17,10 +17,14 @@
   },
   "dependencies": {
     "qs": "^6.7.0"
+    "redux": "^4.0.4",
+    "redux-devtools-extension": "^2.13.8",
+    "redux-logger": "^3.0.6",
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
     "@types/qs": "^6.5.3",
+    "@types/redux-logger": "^3.0.7",
     "jest": "^23.5.0",
     "ts-jest": "^24.0.0"
   }

--- a/packages/widgets-manager/src/configureStore.ts
+++ b/packages/widgets-manager/src/configureStore.ts
@@ -1,0 +1,50 @@
+import { createEpicMiddleware } from 'redux-observable';
+import { createLogger } from 'redux-logger';
+import { createStore, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension/logOnly';
+import { rootReducer } from './reducers';
+import { rootEpic } from './epics';
+
+export const configureStore = (initialState: any, dependencies: any) => {
+
+  const middlewares = [
+  ];
+
+  const enhancers: any[] = [];
+
+  // Ignore next for collection coverage as is something only for DEV environment
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV === 'development') {
+    // Define redux logger
+    const logger: any = createLogger({
+      // ...options
+    });
+
+    middlewares.push(logger);
+  }
+
+  enhancers.push(applyMiddleware(...middlewares));
+
+  // If Redux DevTools Extension is installed use it, otherwise use Redux compose
+  /* eslint-disable no-underscore-dangle */
+  const composeEnhancers = process.env.NODE_ENV !== 'production'
+    && typeof window === 'object'
+    && (<any>window).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    ? (<any>window).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+      actionsBlacklist: ['app/Conversation/OUTGOING_TYPING', 'app/Conversation/INCOMING_TYPING'], // Do not send this actions
+    })
+    : composeWithDevTools({ // Use logOnly minimalist version of Redux DevTools Extension is installed use it, otherwise use Redux compose
+      // options like actionSanitizer, stateSanitizer
+    });
+  /* eslint-enable */
+
+  /* Then create Store */
+  const store = createStore(
+    rootReducer,
+    initialState,
+    composeEnhancers(...enhancers)
+  );
+
+
+  return store;
+}

--- a/packages/widgets-manager/src/reducers/__tests__/apps.spec.ts
+++ b/packages/widgets-manager/src/reducers/__tests__/apps.spec.ts
@@ -1,0 +1,45 @@
+import appsReducer, { initialState } from '../apps';
+import {
+  setApps,
+  syncDataSuccess
+} from '../../store/actions';
+
+describe('When it recieves setApps action', () => {
+  it('Should set the received apps', () => {
+    const mockApps = [
+      { id: 1, name: 'app1' },
+      { id: 2, name: 'app2' },
+      { id: 3, name: 'app3' },
+    ];
+    const actionToTest = setApps(mockApps);
+
+    const stateAfterReducer = appsReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual(expect.arrayContaining(mockApps));
+  });
+});
+
+describe('When it recieves syncDataSuccess action', () => {
+  it('Should sync the received apps', () => {
+    const mockApps = [
+      { id: 1, name: 'app1' },
+      { id: 2, name: 'app2' },
+      { id: 3, name: 'app3' },
+    ];
+    const actionToTest = syncDataSuccess({ apps: mockApps });
+
+    const stateAfterReducer = appsReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual(expect.arrayContaining(mockApps));
+  });
+});
+
+describe('When invalid action type', () => {
+  it('Should not change the state', () => {
+    const actionToTest = { type: 'INVALID' };
+
+    const stateAfterReducer = appsReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual(initialState);
+  });
+});

--- a/packages/widgets-manager/src/reducers/__tests__/mounted_apps.spec.ts
+++ b/packages/widgets-manager/src/reducers/__tests__/mounted_apps.spec.ts
@@ -1,0 +1,104 @@
+import mountedAppReducer, { initialState } from '../mounted_apps';
+import {
+  syncData,
+  mountAppSuccess,
+  unMountAppSuccess,
+} from '../../store/actions';
+
+describe('When it recieves syncData action', () => {
+  it('Should set the received mounted_apps', () => {
+    const mockMountedApps = {
+      1: true,
+      2: false,
+      3: true,
+    };
+
+    const actionToTest = syncData({ mounted_apps: mockMountedApps });
+
+    const stateAfterReducer = mountedAppReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual(mockMountedApps);
+  });
+});
+
+describe('When it recieves mountAppSuccess action', () => {
+  describe('When app first mounted', () => {
+    it('Should correctly set the mounted App', () => {
+      const mockInitialState = {};
+  
+      const actionToTest = mountAppSuccess(2);
+  
+      const stateAfterReducer = mountedAppReducer(mockInitialState, actionToTest);
+  
+      expect(stateAfterReducer).toEqual({
+        2: true,
+      });
+    });
+  });
+
+  describe('When app was previously unmounted', () => {
+    it('Should correctly set the mounted App', () => {
+      const mockInitialState = {
+        1: true,
+        2: false,
+        3: true,
+      };
+  
+      const actionToTest = mountAppSuccess(2);
+  
+      const stateAfterReducer = mountedAppReducer(mockInitialState, actionToTest);
+  
+      expect(stateAfterReducer).toEqual({
+        1: true,
+        2: true,
+        3: true,
+      });
+    });
+  });
+});
+
+describe('When it recieves unMountAppSuccess action', () => {
+  describe('When app first unmounted', () => {
+    it('Should correctly set the unmounted App', () => {
+      const mockInitialState = {};
+  
+      const actionToTest = unMountAppSuccess(2);
+  
+      const stateAfterReducer = mountedAppReducer(mockInitialState, actionToTest);
+  
+      expect(stateAfterReducer).toEqual({
+        2: false,
+      });
+    });
+  });
+
+  describe('When app was previously unmounted', () => {
+    it('Should correctly set the unmounted App', () => {
+      const mockInitialState = {
+        1: true,
+        2: true,
+        3: true,
+      };
+  
+      const actionToTest = unMountAppSuccess(2);
+  
+      const stateAfterReducer = mountedAppReducer(mockInitialState, actionToTest);
+
+      expect(stateAfterReducer).toEqual({
+        1: true,
+        2: false,
+        3: true,
+      });
+    });
+  });
+});
+
+describe('When invalid action type', () => {
+  it('Should not change the state', () => {
+    const actionToTest = { type: 'INVALID' };
+
+    const stateAfterReducer = mountedAppReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual(initialState);
+  });
+});

--- a/packages/widgets-manager/src/reducers/__tests__/user.spec.ts
+++ b/packages/widgets-manager/src/reducers/__tests__/user.spec.ts
@@ -1,0 +1,34 @@
+import userReducer, { initialState } from '../user';
+import { updateUserData } from '../../store/actions';
+
+describe('When it recieves updateUserData action', () => {
+  it('Should update the user in the app', () => {
+    const mockUser = {
+      uid: 'uid123',
+      name: 'Sandino',
+      metadata: { vip: true },
+      isAnonymous: true,
+      extra_param1: 'something1',
+      extra_param2: 'something2',
+    };
+    const actionToTest = updateUserData(mockUser);
+
+    const stateAfterReducer = userReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual({
+      uid: 'uid123',
+      isAnonymous: true,
+      metadata: { vip: true },
+    });
+  });
+});
+
+describe('When invalid action type', () => {
+  it('Should not change the state', () => {
+    const actionToTest = { type: 'INVALID' };
+
+    const stateAfterReducer = userReducer(initialState, actionToTest);
+
+    expect(stateAfterReducer).toEqual(initialState);
+  });
+});

--- a/packages/widgets-manager/src/reducers/apps.ts
+++ b/packages/widgets-manager/src/reducers/apps.ts
@@ -1,0 +1,42 @@
+import { Action } from "../store/types";
+import { ActionType } from "../store/actions";
+import { App } from "../types";
+
+export const initialState = [];
+
+const syncAppsReducer: any = (
+  _previousState: App[] = initialState,
+  action: Action<any>// action.payload = app object
+): App[] => {
+  return action.payload.apps;
+};
+
+const setAppsReducer: any = (
+  _previousState: App[] = initialState,
+  action: Action<any>// action.payload = app object
+): App[] => {
+  return action.payload;
+};
+
+/**
+ * The Application Reducer
+ * @param state: current application state
+ * @param action: the current action fired in the application
+ * @returns state: the new application state
+ */
+const reducer: any = (
+  prevState: App[] = initialState,
+  action: Action
+): App[] => {
+  switch (action.type) {
+    case ActionType.SYNC_DATA_SUCCESS:
+      return syncAppsReducer(prevState, action);
+    case ActionType.SET_APPS:
+      return setAppsReducer(prevState, action);
+  }
+
+  return prevState;
+};
+
+export default reducer;
+

--- a/packages/widgets-manager/src/reducers/index.ts
+++ b/packages/widgets-manager/src/reducers/index.ts
@@ -1,8 +1,11 @@
 import { combineReducers } from 'redux';
 import appsReducer from './apps';
+import mountedAppsReducer from './mounted_apps';
 const rootReducer = combineReducers({
   apps: appsReducer,
+  mounted_apps: mountedAppsReducer,
 })
+
 export {
   rootReducer,
 }

--- a/packages/widgets-manager/src/reducers/index.ts
+++ b/packages/widgets-manager/src/reducers/index.ts
@@ -1,9 +1,12 @@
 import { combineReducers } from 'redux';
 import appsReducer from './apps';
 import mountedAppsReducer from './mounted_apps';
+import userReducer from './user';
+
 const rootReducer = combineReducers({
   apps: appsReducer,
   mounted_apps: mountedAppsReducer,
+  user: userReducer,
 })
 
 export {

--- a/packages/widgets-manager/src/reducers/index.ts
+++ b/packages/widgets-manager/src/reducers/index.ts
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import appsReducer from './apps';
+const rootReducer = combineReducers({
+  apps: appsReducer,
+})
+export {
+  rootReducer,
+}

--- a/packages/widgets-manager/src/reducers/mounted_apps.ts
+++ b/packages/widgets-manager/src/reducers/mounted_apps.ts
@@ -1,0 +1,65 @@
+import { Action } from "../store/types";
+import { ActionType } from "../store/actions";
+import { App, ObjectIndex } from "../types";
+
+export const initialState = {};
+
+const syncMountedAppsReducer: any = (
+  previousState: ObjectIndex<App> = initialState,
+  action: Action<any>// action.payload = app object
+): App[] => {
+  return action.payload.mounted_apps ? action.payload.mounted_apps : previousState;
+};
+
+const mountAppSuccessReducer: any = (
+  previousState: ObjectIndex<App> = initialState,
+  action: Action<number>// action.payload = app id
+): App[] => {
+  const updatedData: any = {}
+  if (action.payload) {
+    updatedData[`${action.payload}`] = true;
+  }
+
+  const newMountedApps = { ...previousState, ...updatedData };
+
+  return newMountedApps;
+};
+
+const unmountAppSuccessReducer: any = (
+  previousState: ObjectIndex<App> = initialState,
+  action: Action<number>// action.payload = appId
+): App[] => {
+  const updatedData: any = {}
+  if (action.payload) {
+    updatedData[`${action.payload}`] = false;
+  }
+
+  const newMountedApps = { ...previousState, ...updatedData };
+
+  return newMountedApps;
+};
+
+/**
+ * The Application Reducer
+ * @param state: current application state
+ * @param action: the current action fired in the application
+ * @returns state: the new application state
+ */
+const reducer: any = (
+  prevState: ObjectIndex<App> = initialState,
+  action: Action
+): ObjectIndex<App> => {
+  switch (action.type) {
+    case ActionType.SYNC_DATA:
+      return syncMountedAppsReducer(prevState, action);
+    case ActionType.MOUNT_APP_SUCCESS:
+      return mountAppSuccessReducer(prevState, action);
+    case ActionType.UNMOUNT_APP_SUCCESS:
+      return unmountAppSuccessReducer(prevState, action);
+  }
+
+  return prevState;
+};
+
+export default reducer;
+

--- a/packages/widgets-manager/src/reducers/user.ts
+++ b/packages/widgets-manager/src/reducers/user.ts
@@ -1,0 +1,33 @@
+import { Action } from "../store/types";
+import { ActionType } from "../store/actions";
+import { App } from "../types";
+
+export const initialState = false;
+
+const updateUserDataReducer: any = (
+  _previousState: any = initialState,
+  action: Action<any>// action.payload = app object
+): App[] => {
+  return action.payload;
+};
+
+/**
+ * The User Reducer
+ * @param state: current application state
+ * @param action: the current action fired in the application
+ * @returns state: the new application state
+ */
+const reducer: any = (
+  prevState: any = initialState,
+  action: Action
+): any => {
+  switch (action.type) {
+    case ActionType.UPDATE_USER_DATA:
+      return updateUserDataReducer(prevState, action);
+  }
+
+  return prevState;
+};
+
+export default reducer;
+

--- a/packages/widgets-manager/src/store/actions.ts
+++ b/packages/widgets-manager/src/store/actions.ts
@@ -1,0 +1,57 @@
+import { ActionCreator } from "./types";
+import { action } from "./utils";
+import { App } from "../types";
+
+/**
+ * Here we declare the application action names
+ */
+export enum ActionType {
+  UPDATE_USER_DATA = "@@actions/UPDATE_USER_DATA",
+  SYNC_DATA = "@@actions/SYNC_DATA",
+  SYNC_DATA_SUCCESS = "@@actions/SYNC_DATA_SUCCESS",
+  MOUNT_APP = "@@actions/MOUNT_APP",
+  MOUNT_APP_SUCCESS = "@@actions/MOUNT_APP_SUCCESS",
+  UNMOUNT_APP = "@@actions/UNMOUNT_APP",
+  UNMOUNT_APP_SUCCESS = "@@actions/UNMOUNT_APP_SUCCESS",
+  GET_APPS = "@@actions/GET_APPS",
+  GET_APPS_SUCCESS = "@@actions/GET_APPS_SUCCESS",
+  SET_APPS = "@@actions/SET_APPS",
+}
+
+/**
+ * Action creators
+ */
+export const mountApp: ActionCreator<string> = (appId: number, initialData: any) =>
+  action<string>(ActionType.MOUNT_APP, { appId, initialData });
+
+export const mountAppSuccess: ActionCreator<string> = (app: App) =>
+  action<string>(ActionType.MOUNT_APP_SUCCESS, app);
+
+export const unMountApp: ActionCreator<string> = (appId: number) =>
+  action<string>(ActionType.UNMOUNT_APP, appId);
+
+export const unMountAppSuccess: ActionCreator<string> = (appId: number) =>
+  action<string>(ActionType.UNMOUNT_APP_SUCCESS, appId);
+
+export const syncData: ActionCreator<string> = (data: any) =>
+  action<string>(ActionType.SYNC_DATA, data);
+
+export const syncDataSuccess: ActionCreator<string> = (data: any) =>
+  action<string>(ActionType.SYNC_DATA_SUCCESS, data);
+
+export const getApps: ActionCreator<void> = () =>
+  action<void>(ActionType.GET_APPS);
+
+export const getAppsSuccess: ActionCreator<App[]> = (apps: App[]) =>
+  action<any[]>(ActionType.GET_APPS_SUCCESS, apps);
+
+export const setApps: ActionCreator<string> = (apps: App[]) =>
+  action<string>(ActionType.SET_APPS, apps);
+
+export const updateUserData: ActionCreator<string> = (firebaseUser: any) => {
+  return action<string>(ActionType.UPDATE_USER_DATA, {
+      uid: firebaseUser.uid,
+      isAnonymous: firebaseUser.isAnonymous,
+      metadata: firebaseUser.metadata,
+  });
+}

--- a/packages/widgets-manager/src/store/initialState.ts
+++ b/packages/widgets-manager/src/store/initialState.ts
@@ -1,0 +1,11 @@
+import { ApplicationState } from "./types";
+
+const initialState: ApplicationState = {
+  apps: [],
+  mounted_apps: {},
+  user: false,
+}
+
+export {
+  initialState,
+};

--- a/packages/widgets-manager/src/store/types.ts
+++ b/packages/widgets-manager/src/store/types.ts
@@ -1,0 +1,42 @@
+import { ActionType } from "./actions";
+import { App, ObjectIndex } from "../types";
+/**
+ * The application state interface.
+ * Here we declare what data will be stored in our application state.
+ */
+export interface ApplicationState {
+  readonly apps: App[];
+  readonly mounted_apps: ObjectIndex<number>;
+  readonly user: any;
+}
+
+
+/**
+ * Reducers specify how the application's state changes in response to actions.
+ * (prevState, action) => newState
+ */
+export type Reducer = (
+  previousState: ApplicationState,
+  action: Action
+) => ApplicationState;
+
+/**
+ * ActionCreator is a function that can take any number of arguments and must return an Action
+ */
+export type ActionCreator<T = any> = (
+  arg1?: any,
+  arg2?: any,
+  arg3?: any,
+  arg4?: any,
+  arg5?: any,
+  ...rest: any[]
+) => Action<T>;
+
+/**
+ * Action interface
+ */
+export interface Action<T = any> {
+  type: ActionType;
+  payload?: T;
+}
+

--- a/packages/widgets-manager/src/store/utils.ts
+++ b/packages/widgets-manager/src/store/utils.ts
@@ -1,0 +1,12 @@
+import { ActionType } from "./actions";
+import { Action } from "./types";
+
+/**
+ * Function which helps to create actions without mistakes
+ * @param type
+ * @param payload
+ */
+export const action = <T>(type: ActionType, payload?: any): Action<T> => ({
+  type,
+  payload
+});


### PR DESCRIPTION
**Description**

We want to handle the widgets-manager library state. This will help us have a centralized state that makes our library to be more predictable and to behave consistently.

**Acceptance Criteria**

- [x] State is only modified via reducers
- [x] Loaded apps are persisted in the state
- [x] Mounted / Unmounted apps are persisted in the state
- [x] Current user session is persisted in the state

**Commercial Value**

It will help us to have apps that can not be opened twice if we want to (for example because user closed the app).

**Customer Value**

Customers will not be prompted many times after closing an app. We can remember user state so we can launch the same apps he was viewing in the last session.

**Help screen shoots**

This is how the state shape is (just plain object with 3 main keys). Each reducer is in charge of updating one part of the state

<img width="864" alt="Screen Shot 2019-10-29 at 1 56 59 AM" src="https://user-images.githubusercontent.com/466105/67738989-91cad580-f9ef-11e9-8a33-a36aaab31b37.png">

Each of those apps are just plain objects that represents our apps (same as ever):
<img width="860" alt="Screen Shot 2019-10-29 at 1 56 43 AM" src="https://user-images.githubusercontent.com/466105/67739024-c048b080-f9ef-11e9-8fb2-1722524ade59.png">

