### PR TITLE
Widget manager (2/3) add library to handle side effects

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,13 @@
 docker-defaults: &docker-defaults
   docker:
     # specify the version you desire here
-    - image: circleci/node:latest-browsers
+    - image: circleci/node:12
   working_directory: ~/chat-utils
 
 build-and-test-defaults: &build-and-test-defaults
   docker:
     # specify the version you desire here
-    - image: circleci/node:latest-browsers
+    - image: circleci/node:12
   working_directory: ~/chat-utils
   steps:
       - run:

--- a/packages/widgets-manager/package.json
+++ b/packages/widgets-manager/package.json
@@ -22,14 +22,18 @@
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
-    "reselect": "^4.0.0"
+    "redux-observable": "^1.2.0",
+    "reselect": "^4.0.0",
+    "rxjs": "^6.5.3"
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
     "@types/lodash": "^4.14.144",
     "@types/qs": "^6.5.3",
     "@types/redux-logger": "^3.0.7",
+    "@types/redux-mock-store": "^1.0.1",
     "jest": "^23.5.0",
+    "redux-mock-store": "^1.5.3",
     "ts-jest": "^24.0.0"
   }
 }

--- a/packages/widgets-manager/src/configureStore.ts
+++ b/packages/widgets-manager/src/configureStore.ts
@@ -6,8 +6,12 @@ import { rootReducer } from './reducers';
 import { rootEpic } from './epics';
 
 export const configureStore = (initialState: any, dependencies: any) => {
+  const epicMiddleware = createEpicMiddleware({ dependencies });
 
+  // Create the store with three middlewares (the order here is important)
+  // 1. epicMiddleware: Makes redux-observables work
   const middlewares = [
+    epicMiddleware,
   ];
 
   const enhancers: any[] = [];
@@ -45,6 +49,8 @@ export const configureStore = (initialState: any, dependencies: any) => {
     composeEnhancers(...enhancers)
   );
 
+  /* Finally attach epics to store */
+  epicMiddleware.run(rootEpic);
 
   return store;
 }

--- a/packages/widgets-manager/src/store/types.ts
+++ b/packages/widgets-manager/src/store/types.ts
@@ -1,5 +1,7 @@
+import { Observable } from "rxjs";
 import { ActionType } from "./actions";
 import { App, ObjectIndex } from "../types";
+
 /**
  * The application state interface.
  * Here we declare what data will be stored in our application state.
@@ -19,6 +21,28 @@ export type Reducer = (
   previousState: ApplicationState,
   action: Action
 ) => ApplicationState;
+
+export type EpicDependencies = {
+  selectors: {
+    selectCurrentUserUid: (state: ApplicationState) => any,
+    selectApps: (state: ApplicationState) => any,
+  },
+  sideEffects: {
+    mountApp: (appId: number) => void,
+    unMountApp: (appId: number) => void,
+    updateDocument: (collectionName: string, documentId: string, data: any) => void,
+    executeAppMethod: (appSlug: string, method: string, data: any) => void
+  }
+}
+/**
+ * Epic is a function which takes an Observable of actions and returns an Observable of actions.
+ * Actions in, actions out, simple as that.
+ */
+export type Epic = (
+  action$: Observable<Action>,
+  state$?: Observable<ApplicationState>,
+  dependencies?: EpicDependencies,
+) => Observable<Action>;
 
 /**
  * ActionCreator is a function that can take any number of arguments and must return an Action

--- a/packages/widgets-manager/src/types.ts
+++ b/packages/widgets-manager/src/types.ts
@@ -134,6 +134,7 @@ export interface PositionStrategy {
 }
 
 export type PromisedFunction = (appId: number) => Promise<any>;
+export type AppMethod = (appName: string, method: string, args: any[]) => void;
 
 export const makeHTMLFloatType = (rawString: string): HTMLFloatType => {
   switch (rawString) {

--- a/packages/widgets-manager/src/utils/__tests__/firebase.spec.ts
+++ b/packages/widgets-manager/src/utils/__tests__/firebase.spec.ts
@@ -1,0 +1,69 @@
+import 'firebase/firestore';
+import 'firebase/auth';
+import 'firebase/firestore';
+
+import { saveDocument, updateDocument, initializeFirebaseApp } from '../firebase';
+
+// const mockInitializeApp = jest.fn();
+const mockOnAuthStateChanged = jest.fn();
+const mockSignInAnonymously = jest.fn();
+const mockSet = jest.fn();
+
+mockSet.mockReturnValue(true);
+
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(),
+  auth: jest.fn(() => ({
+    onAuthStateChanged: mockOnAuthStateChanged,
+    signInAnonymously: mockSignInAnonymously,
+  })),
+  firestore: () => ({
+    collection: () => ({
+      doc: jest.fn(() => ({
+        set: mockSet
+      }))
+    })
+  }),
+}));
+
+describe('firebase', () => {
+  describe('initializeFirebaseApp', () => {
+    const mockStore = jest.fn();
+
+    initializeFirebaseApp(mockStore);
+
+    it('Call the firebase.auth.onAuthStateChanged', () => {
+      expect(mockOnAuthStateChanged).toBeCalled();
+    });
+    
+    it('Call the firebase.auth.signInAnonymously', () => {
+      expect(mockSignInAnonymously).toBeCalled();
+    });
+  });
+
+  describe('saveDocument', () => {
+    const mockObject = {
+      conversationId: 'MOCK-1',
+      content: '<html>',
+    };
+
+    saveDocument('mock-collection-name', 'myDocId', mockObject);
+
+    it('Call the firebase sdk with proper params', () => {
+      expect(mockSet).toBeCalledWith(mockObject, { merge: true });
+    });
+  });
+  
+  describe('updateDocument', () => {
+    const mockObject = {
+      conversationId: 'MOCK-1',
+      content: '<html>',
+    };
+
+    updateDocument('mock-collection-name', 'myDocId', mockObject);
+
+    it('Call the firebase sdk with proper params', () => {
+      expect(mockSet).toBeCalledWith(mockObject, { merge: true });
+    });
+  });
+})

--- a/packages/widgets-manager/src/utils/firebase.ts
+++ b/packages/widgets-manager/src/utils/firebase.ts
@@ -1,0 +1,94 @@
+// ts-ignore
+import * as Firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/firestore';
+import { updateUserData, syncData } from '../store/actions';
+
+const debug = require('debug')('widgets-manager:utils:firebase');
+
+const config = {
+  apiKey: "AIzaSyATST9016Y3SCCnyEM0quH1UoCfbv35MEo",
+  authDomain: "lt-generic-store.firebaseapp.com",
+  databaseURL: "https://lt-generic-store.firebaseio.com",
+  projectId: "lt-generic-store",
+  storageBucket: "lt-generic-store.appspot.com",
+  messagingSenderId: "855806900184",
+  appId: "1:855806900184:web:789d34f4cf40dbd1"
+}
+
+const collectionName = 'users';
+const stateSelector = (state: any) => state;
+
+const initializeFirebaseApp = (store: any): Promise<any> => {
+  Firebase.initializeApp(config);
+
+  return new Promise((resolve, reject) => {
+    Firebase.auth().onAuthStateChanged(function(user) {
+      if (user) {
+        // User is signed in.
+        debug('Got firebase user:', user);
+        store.dispatch(updateUserData(user));
+        linkStoreWithPath(`${user.uid}`, syncData, stateSelector)(
+          Firebase.firestore(),
+          store
+        );
+        resolve();
+      } else {
+        // User is signed out.
+        debug('Firebase user logout');
+      }
+    });
+
+    Firebase.auth().signInAnonymously().catch(function(error) {
+      // Handle Errors here.
+      console.error('Firebase auth error:', error);
+      reject(error);
+      // ...
+    });
+  });
+}
+
+const linkStoreWithDb = (fromDb: any) => {
+  return (db: any, store: any) => {
+    fromDb(store, db);
+  };
+}
+
+const linkStoreWithPath = (path: string, actionCreator: any, selector: any) => {
+  return (db: any, store: any) => {
+    debug('linkStoreWithPath:', path, selector(store.getState()));
+
+    const fromDb = (store: any, db: any) => {
+      db
+        .collection(collectionName)
+        .doc(path)
+        .onSnapshot((snapshot: any) => {
+          debug('fromDb doc.onSnapshot, snapshot', snapshot.data());
+          store.dispatch(actionCreator(snapshot.data()));
+        });
+    };
+
+    return linkStoreWithDb(fromDb)(db, store);
+  };
+}
+
+const saveDocument = (collectionName: string, documentId: string, document: any) => {
+  return Firebase.firestore()
+    .collection(collectionName)
+    .doc(documentId)
+    .set(document, { merge: true })
+}
+
+const updateDocument = (collectionName: string, documentId: string, document: any) => {
+  return Firebase.firestore()
+    .collection(collectionName)
+    .doc(documentId)
+    .set(document, { merge: true })
+}
+
+export {
+  initializeFirebaseApp,
+  saveDocument,
+  updateDocument,
+  linkStoreWithPath,
+}


### PR DESCRIPTION
**Description**

We want to handle the widgets-manager library state. This will help us have a centralized state that makes our library to be more predictable and to behave consistently.

**Acceptance Criteria**

- [x] Adds a library to handle side effects in redux (redux-observable)
- [x] Define side effects helper to save / update data in firebase and keep in sync
- [x] Does Anonymous auth in firebase to have the firebase data scoped to a user's session

**Commercial Value**

It will allow us to execute side effects (call HTTP method, connect with external service or any function) whenever our state changes

**Screenshots**

This is firebase database:

<img width="1440" alt="Screen Shot 2019-10-29 at 2 01 01 AM" src="https://user-images.githubusercontent.com/466105/67739138-33eabd80-f9f0-11e9-832b-ec6c37811002.png">

