### PR TITLE
Feature Apps SDK add `on` method

### DIFF
--- a/packages/apps-sdk/package.json
+++ b/packages/apps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-talk/apps-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SDK for apps running on letstalk plataform",
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/apps-sdk/src/__tests__/sdk.spec.ts
+++ b/packages/apps-sdk/src/__tests__/sdk.spec.ts
@@ -170,4 +170,26 @@ describe('SDK', () => {
 
     expect(mockedSend).toHaveBeenCalledWith(EVENT_TYPE_NOTIFY_APP_EVENT, expectedSentPayload);
   });
+
+  describe('on method', () => {
+    const mockedOn = jest.fn();
+    const mockClientChannel = jest.fn(() => ({
+      send: jest.fn(() => new Promise((resolve) => resolve(1))),
+    }));
+    const mockListenerChannel = jest.fn(() => ({
+      on: mockedOn,
+    }));
+    const mockCommunicationChannel = {
+      client: mockClientChannel,
+      listener: mockListenerChannel,
+    };
+    const sdk = new SDK(() => mockCommunicationChannel);
+    const mockHandler = jest.fn();
+
+    it('Calls the listener.on method with the correct params', () => {
+      sdk.on('myCustomEvent', mockHandler);
+
+      expect(mockedOn).toHaveBeenCalledWith('myCustomEvent', mockHandler);
+    });
+  });
 });

--- a/packages/apps-sdk/src/sdk.ts
+++ b/packages/apps-sdk/src/sdk.ts
@@ -30,7 +30,7 @@ export class SDK {
   private channelFactory: () => any;
   private channelManager: any;
   private sendChannel: any;
-  private recieveChannel: any;
+  private receiveChannel: any;
   private handlers: any;
 
   constructor(channelFactory = () => postRobot) {
@@ -59,14 +59,14 @@ export class SDK {
     // Define Communication Channels
     this.channelManager = this.channelFactory();
     this.sendChannel = this.channelManager.client({ ...channelConfig, domain: '*' });
-    this.recieveChannel = this.channelManager.listener({ ...channelConfig, domain: '*' });
+    this.receiveChannel = this.channelManager.listener({ ...channelConfig, domain: '*' });
   }
 
   /**
    * setUpListeners Set the handlers for different events we want to listen for
    */
   private setUpListeners(): void {
-    this.recieveChannel.on(EVENT_TYPE_EXECUTE_APP_METHOD, this.handleExecuteAppMethod);
+    this.receiveChannel.on(EVENT_TYPE_EXECUTE_APP_METHOD, this.handleExecuteAppMethod);
   }
 
   /**
@@ -80,7 +80,7 @@ export class SDK {
    * on Define handler for indidividual events types
    */
   public on(eventName: string, handler: (event: EventData) => void) {
-    this.recieveChannel.on(eventName, handler);
+    this.receiveChannel.on(eventName, handler);
   }
 
   private handleExecuteAppMethod(event: EventData) {

--- a/packages/apps-sdk/src/sdk.ts
+++ b/packages/apps-sdk/src/sdk.ts
@@ -76,6 +76,13 @@ export class SDK {
     this.handlers = handlers;
   }
 
+  /**
+   * on Define handler for indidividual events types
+   */
+  public on(eventName: string, handler: (event: EventData) => void) {
+    this.recieveChannel.on(eventName, handler);
+  }
+
   private handleExecuteAppMethod(event: EventData) {
     const { payload } = event.data;
     const { method, args } = payload;


### PR DESCRIPTION
**Description**

Add a new method to the AppsSDK library `on(eventName: string, handler: (event: EventData) => void)` that allows apps to register a handler to events that are interested in handling
 
**Acceptance criteria**

The most important changes here where:

- [x] Should expose the method `on`

**Commercial value**

Allow apps to react to events that they wish to handle from the container window or parent
