### PR TITLE
Widgets manager add getMountedApps method

### DIFF
--- a/packages/widgets-manager/CHANGELOG.md
+++ b/packages/widgets-manager/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased [2.3.0?] - 2020-01-21
+### Added
+- Added method `getMountedApps` to the manager
+
 ## Hotfix [2.2.1, 2.2.2, 2.2.3, 2.2.4] - 2020-01-05
 ### Fixed
 - Disable the Sync of firebase with redux -> Make a TODO to figure out corner

--- a/packages/widgets-manager/package.json
+++ b/packages/widgets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lets-talk/widgets-manager",
-  "version": "2.3.0-beta-2",
+  "version": "2.3.0",
   "description": "Minimal widgets manager implementation to allow load / remove apps on a page",
   "scripts": {
     "prepublishOnly": "tsc",

--- a/packages/widgets-manager/src/configureManager.spec.ts
+++ b/packages/widgets-manager/src/configureManager.spec.ts
@@ -1,0 +1,20 @@
+import { App } from "./types";
+import { setupManager, } from './configureManager';
+
+describe('configureManager', () => {
+  it('Returns an object with all the required public methods', async () => {
+    const mockRegisteredApps: App[] = [];
+    const mockInitialData = {};
+    const mockSideEffects = {};
+
+    const manager = await setupManager(mockRegisteredApps, mockInitialData, mockSideEffects);
+    expect(manager).toMatchObject({
+      mountApp: expect.any(Function),
+      unMountApp: expect.any(Function),
+      getAppByName: expect.any(Function),
+      getAllAppsForNamespace: expect.any(Function),
+      getMountedApps: expect.any(Function),
+      updateAllAppSettings: expect.any(Function),
+    })
+  });
+});

--- a/packages/widgets-manager/src/configureManager.ts
+++ b/packages/widgets-manager/src/configureManager.ts
@@ -61,6 +61,7 @@ export const setupManager = async (
     unMountApp: (appName: string) => store.dispatch(unMountApp(appName)),
     getAppByName: appManager.getAppByName,
     getAllAppsForNamespace: appManager.getAllAppsForNamespace,
+    getMountedApps: appManager.getMountedApps,
     updateAllAppSettings: appManager.updateAllAppSettings,
   };
 };

--- a/packages/widgets-manager/src/manager.spec.ts
+++ b/packages/widgets-manager/src/manager.spec.ts
@@ -8,6 +8,12 @@ jest.mock('./utils/firebase', () => ({
   initializeFirebaseApp: jest.fn(() => Promise.resolve(1)),
 }));
 
+const mockSelectCurrentlyMountedApps = jest.fn();
+jest.mock('./selectors/apps', () => ({
+  ...jest.requireActual('./utils/firebase'),
+  selectCurrentlyMountedApps: mockSelectCurrentlyMountedApps,
+}));
+
 const mockPositionRelativeToElement: AppPosition = {
   type: 'relative-to-element',
   payload: {
@@ -156,10 +162,12 @@ const mockPopupApp: App = {
 }
 
 const mockApps = [mockApp1, mockApp2, mockApp3, mockPopupApp];
+const mockMountedApps = [mockApp1, mockApp3];
 
 jest.mock('./selectors/apps', () => ({
   ...jest.requireActual('./selectors/apps'),
   selectApps: jest.fn(() => mockApps),
+  selectCurrentlyMountedApps: jest.fn(() => mockMountedApps),
 }));
 
 describe('AppManager', () => {
@@ -315,4 +323,22 @@ describe('AppManager', () => {
     });
   });
 
+  describe('getMountedApps', () => {
+    it('Correctly get the number of apps', () => {
+      const manager = new AppManager(mockGridManager);
+
+      const mountedApps = manager.getMountedApps();
+      expect(mountedApps.length).toBe(2);
+    });
+    
+    it('Correctly get all apps', () => {
+      const manager = new AppManager(mockGridManager);
+
+      const mountedApps = manager.getMountedApps();
+      expect(mountedApps).toContainEqual(mockApp1);
+      expect(mountedApps).not.toContainEqual(mockApp2);
+      expect(mountedApps).toContainEqual(mockApp3);
+      expect(mountedApps).not.toContainEqual(mockPopupApp);
+    });
+  });
 });

--- a/packages/widgets-manager/src/manager.ts
+++ b/packages/widgets-manager/src/manager.ts
@@ -6,7 +6,7 @@ import { POSITION_RELATIVE_TO_ELEMENT, POSITION_RELATIVE_TO_PLACE, POSITION_FIXE
 import { GridManager } from './grid';
 import { App, GridCell, AppInlineStyle } from "./types";
 import { Store } from 'redux';
-import { selectApps } from './selectors/apps';
+import { selectApps, selectCurrentlyMountedApps } from './selectors/apps';
 import { initialState } from './store/initialState';
 import { ApplicationState } from './store/types';
 
@@ -286,6 +286,10 @@ export class AppManager {
 
   public getApps = (): App[] => {
     return selectApps(this.state);
+  }
+  
+  public getMountedApps = (): App[] => {
+    return selectCurrentlyMountedApps(this.state);
   }
 
   public updateAllAppSettings = () => {

--- a/packages/widgets-manager/src/selectors/__tests__/apps.spec.ts
+++ b/packages/widgets-manager/src/selectors/__tests__/apps.spec.ts
@@ -1,4 +1,4 @@
-import { selectApps } from '../apps';
+import { selectApps, selectCurrentlyMountedApps } from '../apps';
 
 describe('selectApps', () => {
   it('Get the apps list', () => {
@@ -22,6 +22,64 @@ describe('selectApps', () => {
     const portion = selectApps(mockState);
 
     expect(portion).toMatchObject(expectedApps);
+  });
+});
+
+describe('selectCurrentlyMountedApps', () => {
+  describe('When app has not been mounted', () => {
+    const expectedApps = [
+      { id: 1, name: 'app1', slug: 'app-1', initialData: { metadata: { vip: true }} },
+      { id: 3, name: 'app3', slug: 'app-3'  },
+    ];
+
+    const mockState = {
+      initial_data: {
+        'app-1': { metadata: { vip: true }},
+      },
+      apps: [
+        { id: 1, name: 'app1', slug: 'app-1' },
+        { id: 2, name: 'app2', slug: 'app-2' },
+        { id: 3, name: 'app3', slug: 'app-3'  },
+      ],
+      mounted_apps: {
+        'app-1': true,
+        'app-3': true
+      }
+    };
+
+    it('Get the apps currently mounted', () => {  
+      const portion = selectCurrentlyMountedApps(mockState);
+  
+      expect(portion).toMatchObject(expectedApps);
+    });
+
+  });
+
+  describe('When app has been unmounted', () => {
+    const expectedApps = [
+      { id: 1, name: 'app1', slug: 'app-1', initialData: { metadata: { vip: true }} },
+    ];
+
+    const mockState = {
+      initial_data: {
+        'app-1': { metadata: { vip: true }},
+      },
+      apps: [
+        { id: 1, name: 'app1', slug: 'app-1' },
+        { id: 2, name: 'app2', slug: 'app-2' },
+        { id: 3, name: 'app3', slug: 'app-3'  },
+      ],
+      mounted_apps: {
+        'app-1': true,
+        'app-2': false,
+        'app-3': false
+      }
+    };
+    it('Get the apps currently mounted', () => {  
+      const portion = selectCurrentlyMountedApps(mockState);
+  
+      expect(portion).toMatchObject(expectedApps);
+    });
   });
 });
 

--- a/packages/widgets-manager/src/selectors/apps.ts
+++ b/packages/widgets-manager/src/selectors/apps.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "reselect"
 import { selectAppsInitialData } from "./initial_data";
 import { App } from "../types";
+import { selectMountedApps } from "./mounted_apps";
 
 const debug = require('debug')('widgets-manager:selectors:apps');
 
@@ -18,7 +19,23 @@ const selectApps = createSelector(
   }
 );
 
+const selectCurrentlyMountedApps = createSelector(
+  getAllApps,
+  selectAppsInitialData,
+  selectMountedApps,
+  (apps, appsInitialData, mountedApps) => {
+    return apps
+    .filter((app:App) => Boolean(mountedApps[app.slug]))
+    .map((app: App) => {
+      const appInitialData = appsInitialData[app.slug] || {};
+      debug('selectApps. app, appsInitialData, appInitialData:', app, appsInitialData, appInitialData);
+      return ({ ...app, initialData: appInitialData});
+    });
+  }
+);
+
 
 export {
   selectApps,
+  selectCurrentlyMountedApps,
 }

--- a/packages/widgets-manager/src/types.ts
+++ b/packages/widgets-manager/src/types.ts
@@ -1,4 +1,3 @@
-import { AppPosition, relationTypeY } from './types';
 export type PayloadType = 'html' | 'json' | 'markdown' | 'lt-webrtc' | 'lt-basic-container' | 'lt-basic-container-multimedia';
 export type relationTypeX = 'LL' | 'LR' | 'RL' | 'RR';
 export type relationTypeY = 'TT' | 'TB' | 'BT' | 'BB';


### PR DESCRIPTION
**Description**

Add a new method to the widget-apps library `getMountedApps: () => App[]` that allows apps to register a handler to events that are interested in handling
 
**Acceptance criteria**

The most important changes here where:

- [x] Should expose the method `getMountedApps`

**Commercial value**

Allow users of this library to get the list of currently mounted apps
