### PR TITLE
Handle duplicated ids at renderWidget case

### DIFF
--- a/packages/grid-manager/index.html
+++ b/packages/grid-manager/index.html
@@ -5,6 +5,83 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>LT-Proxy-Channels</title>
+    <script>
+      var remount_widget = [
+        {
+          id: 'app-1',
+          extra: {
+            slug: 'bci',
+            params: null
+          },
+          iframeType: 'lt-basic-container-multimedia',
+          src: 'https://www.yofla.com/black-screen/',
+          kind: 'iframe',
+          addons: [],
+          position: {
+            relation: 'relative-to-viewport',
+            reference: {
+              web: 'bottom-right',
+              tablet: 'bottom-left',
+              mobile: 'bottom'
+            },
+            element: null,
+            display: 'fixed'
+          },
+          dimensions: {
+            tablet: {
+              zIndex: 9999,
+              borderRadius: '10px 10px 0 0',
+              fullSize: false,
+              animate: true,
+              elevation: 2,
+              styles: null,
+              size: {
+                width: 360,
+                height: 460
+              },
+              offset: {
+                x: {
+                  relationType: 'LL',
+                  value: 15
+                },
+                y: {
+                  relationType: 'BB',
+                  value: 0
+                }
+              }
+            },
+            web: {
+              fullSize: false,
+              animate: true,
+              elevation: 2,
+              styles: null,
+              borderRadius: '10px 10px 0 0',
+              size: {
+                width: 460,
+                height: 560
+              },
+              offset: {
+                x: {
+                  relationType: 'RR',
+                  value: 15
+                },
+                y: {
+                  relationType: 'BB',
+                  value: 1
+                }
+              }
+            },
+            mobile: null
+          }
+        },
+      ];
+
+      function remountWidget() {
+        if(window.manager) {
+          window.manager.renderWidgets(remount_widget)
+        }
+      }
+    </script>
     <style>
       #box-1 {
         border: 1px solid black;
@@ -40,7 +117,7 @@
     <div id="box-2"></div>
     <div>
       <button id="left-case">left-case</button>
-      <button id="right-case">right-case</button>
+      <button id="right-case" onclick="remountWidget()">re-mount right widget</button>
       <div id="content">
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Cum tempora unde quidem? Quasi veritatis nobis vitae facere excepturi, cum voluptate, doloribus magnam ea id voluptatibus. Natus commodi debitis adipisci explicabo!</p>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Cum tempora unde quidem? Quasi veritatis nobis vitae facere excepturi, cum voluptate, doloribus magnam ea id voluptatibus. Natus commodi debitis adipisci explicabo!</p>

--- a/packages/grid-manager/src/dom/utils.ts
+++ b/packages/grid-manager/src/dom/utils.ts
@@ -145,7 +145,7 @@ export const getPositionRelativeToApp = (props: RelativeAppPositionProps) => {
   const relativePosition = getRelativePositionToApp(addonSize, offset);
   const transformToCssKey = reduce(
     relativePosition,
-    (acc, val, key) => (!!val ? { ...acc, [key]: `${val}px` } : acc),
+    (acc, val, key) => (val !== null ? { ...acc, [key]: `${val}px` } : acc),
     {}
   );
 
@@ -246,7 +246,7 @@ export const getPositionRelativeToViewport = (props: RelativePositionProps) => {
     ? { top: 0, left: 0 }
     : reduce(
         relativePosition,
-        (acc, val, key) => (!!val ? { ...acc, [key]: `${val}px` } : acc),
+        (acc, val, key) => (val !== null ? { ...acc, [key]: `${val}px` } : acc),
         {}
       );
   const parseBorderRadius =

--- a/packages/grid-manager/src/widgetsMachine/__test__/actions.test.ts
+++ b/packages/grid-manager/src/widgetsMachine/__test__/actions.test.ts
@@ -181,7 +181,8 @@ describe('Actions machine module', () => {
     it('should be called with the correct arguments', () => {
       const context = {
         widgetsIds: [],
-        widgets: {}
+        widgets: {},
+        renderCycle: {widgetsInDom: []}
       }
       const event = {type: '', widgets:[{}] }
       setWidgetsRulesSpy(context, event)
@@ -205,7 +206,8 @@ describe('Actions machine module', () => {
     it('should log duplicated keys', async () => {
       const context = {
         widgetsIds: [1,2,3,4],
-        widgets: {}
+        widgets: {},
+        renderCycle: {widgetsInDom: []}
       }
       const event = {type: '', widgets:[{
         id: 2,
@@ -218,7 +220,8 @@ describe('Actions machine module', () => {
     it('should return a valid widget model', async () => {
       const context = {
         widgetsIds: [1],
-        widgets: {}
+        widgets: {},
+        renderCycle: {widgetsInDom: []}
       }
       const event = {type: '', widgets:[{
         id: 2,

--- a/packages/grid-manager/src/widgetsMachine/actions.ts
+++ b/packages/grid-manager/src/widgetsMachine/actions.ts
@@ -131,6 +131,8 @@ export const setWidgetsRules = (
     throw new Error('widgets value can`t be empty');
   }
 
+  const { widgetsIds, renderCycle: {widgetsInDom}} = context
+
   const widgetsParsed = event.widgets.reduce(
     (acc, widget: WidgetRules) => ({
       ids: [...acc.ids, widget.id],
@@ -146,16 +148,22 @@ export const setWidgetsRules = (
   );
 
   const ids = [...context.widgetsIds, ...widgetsParsed.ids];
-  const mergeIds = uniq(ids);
-
+  const mergeIds = uniq(ids)
   // if the length differ we try to write the same widget to time
   // By design I don't want to trow an error and only log (always last set wins)
   if (mergeIds.length !== ids.length) {
     console.log(`Trying to duplicate widget in model ids: ${[...ids]}`);
+    // if the widget is rendered I remove the node and make the
+    // reconciliation flow continue as always
+    widgetsInDom.forEach((widget) => {
+      if(widget.id in widgetsParsed.widgets) {
+        removeNodeRef(widget.ref)
+      }
+    })
   }
 
   return Promise.resolve({
-    ids,
+    ids: mergeIds,
     widgets: {
       ...widgetsParsed.widgets,
       ...context.widgets
@@ -294,9 +302,7 @@ export const reconcileWidgets = (context: WidgetsMachineCtx) => {
 export const renderWidgetsInDom = (context: WidgetsMachineCtx) => {
   const { requireGlobalUpdate, renderCycle, widgetsIds, widgets } = context;
   const { widgetsInDom, updateCycle, positionsInUse } = renderCycle;
-
   let prevWidgetsRefs = widgetsInDom ? widgetsInDom : [];
-  // console.log({ updateCycle, prevWidgetsRefs, requireGlobalUpdate });
 
   if (requireGlobalUpdate) {
     prevWidgetsRefs = [];

--- a/packages/grid-manager/src/widgetsMachine/actions.ts
+++ b/packages/grid-manager/src/widgetsMachine/actions.ts
@@ -147,7 +147,7 @@ export const setWidgetsRules = (
     }
   );
 
-  const ids = [...context.widgetsIds, ...widgetsParsed.ids];
+  const ids = [...widgetsIds, ...widgetsParsed.ids];
   const mergeIds = uniq(ids)
   // if the length differ we try to write the same widget to time
   // By design I don't want to trow an error and only log (always last set wins)


### PR DESCRIPTION
### Description 

Instead of only generate the log that the user is trying to create the same widget for a second time, check if that widget is on the DOM and then remove the node from the user viewport and continue with the normal flow